### PR TITLE
Link pycorgi to MPI explicitly.

### DIFF
--- a/pycorgi/CMakeLists.txt
+++ b/pycorgi/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB SOURCES *.c++ *.h)
 
 pybind11_add_module(pycorgi ${SOURCES})
 target_compile_options(pycorgi PRIVATE ${WARNING_FLAGS})
+target_link_libraries(pycorgi PRIVATE MPI::MPI_CXX)
 
 
 install (TARGETS pycorgi DESTINATION lib)


### PR DESCRIPTION
Previously it was assumed that MPI came with compiler.
However, if tyvi is integrated to runko, it has to be compiled with compiler that supports HIP and we can not depend on MPI compiler wrappers.